### PR TITLE
Do not early-return when the adapter is destructed too early by PHP

### DIFF
--- a/classes/test/adapter/calls.php
+++ b/classes/test/adapter/calls.php
@@ -320,16 +320,9 @@ class calls implements \countable, \arrayAccess, \iteratorAggregate
 			throw new exceptions\logic\invalidArgument('Function is undefined');
 		}
 
-		// A bug in PHP removes this static attribute when destructing all the
-		// object. So accessing it create an error. This is a workaround.
-		if (!isset(self::$callsNumber)) {
-			return $this;
-		}
-
-		if ($position === null)
-		{
-			$position = ++self::$callsNumber;
-		}
+		$position = $position === null
+			? (self::canAddCall() === true ? ++self::$callsNumber : 1)
+			: $position;
 
 		$this->calls[self::getKey($call)][$position] = $call;
 		$this->size++;
@@ -362,5 +355,12 @@ class calls implements \countable, \arrayAccess, \iteratorAggregate
 	private static function buildCall($mixed)
 	{
 		return ($mixed instanceof adapter\call ? $mixed : new adapter\call($mixed));
+	}
+
+	private static function canAddCall()
+	{
+		// A bug in PHP removes this static attribute when destructing all the
+		// object. So accessing it create an error. This is a workaround.
+		return isset(self::$callsNumber);
 	}
 }

--- a/tests/units/classes/asserters/phpResource.php
+++ b/tests/units/classes/asserters/phpResource.php
@@ -18,7 +18,7 @@ class phpResource extends atoum\test
 		$this->testedClass->extends('mageekguy\atoum\asserters\variable');
 	}
 
-	public function test__construct()
+	public function test__construct(asserter\generator $generator, variable\analyzer $analyzer, atoum\locale $locale)
 	{
 		$this
 			->given($this->newTestedInstance)
@@ -29,7 +29,7 @@ class phpResource extends atoum\test
 				->variable($this->testedInstance->getValue())->isNull()
 				->boolean($this->testedInstance->wasSet())->isFalse()
 
-			->given($this->newTestedInstance($generator = new asserter\generator(), $analyzer = new variable\analyzer(), $locale = new atoum\locale()))
+			->given($this->newTestedInstance($generator, $analyzer, $locale))
 			->then
 				->object($this->testedInstance->getGenerator())->isIdenticalTo($generator)
 				->object($this->testedInstance->getAnalyzer())->isIdenticalTo($analyzer)
@@ -57,7 +57,7 @@ class phpResource extends atoum\test
 						->once
 				->string($asserter->getValue())->isEqualTo($value)
 
-				->object($asserter->setWith($value = fopen(__FILE__, 'r')))->isIdenticalTo($asserter)
+				->object($asserter->setWith($value = fopen(atoum\mock\streams\fs\file::get(), 'r')))->isIdenticalTo($asserter)
 				->resource($asserter->getValue())->isEqualTo($value)
 		;
 	}
@@ -67,13 +67,13 @@ class phpResource extends atoum\test
 		$this
 			->given($asserter = $this->newTestedInstance)
 
-			->if($asserter->setWith(fopen(__FILE__, 'r')))
+			->if($asserter->setWith(fopen(atoum\mock\streams\fs\file::get(), 'r')))
 			->then
 				->object($asserter->isOfType('stream'))->isIdenticalTo($asserter)
 
 			->if(
 				$asserter
-					->setWith($value = fopen(__FILE__, 'r'))
+					->setWith($value = fopen(atoum\mock\streams\fs\file::get(), 'r'))
 					->setLocale($locale = new \mock\atoum\locale())
 					->setDiff($diff = new \mock\atoum\tools\diffs\variable()),
 				$this->calling($locale)->_ = $notAResource = uniqid(),


### PR DESCRIPTION
It seems more clear to me this way. Moreover, I would add more detail in the code comment/commit message about the bug : this only happens with atoum VFS streams.

Actually, the adapter is destructed and the `stream_close` method on the virtual stream gets called after that.

The adapter cannot record this call.
